### PR TITLE
fix: import description of Mock.GPIO module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ sudo pip3 install Mock.GPIO
 To import the Mock library at the beginning of your script, use
 
 ```python
-from Mock.GPIO import GPIO
+import Mock.GPIO as GPIO
 ```
 
 or


### PR DESCRIPTION
* `import Mock.GPIO as GPIO` or `from Mock import GPIO` are valid import statements
* replaced invalid import statements with valid ones