### PR TITLE
remove unnecessary sleep

### DIFF
--- a/Mock/GPIO.py
+++ b/Mock/GPIO.py
@@ -73,7 +73,6 @@ def setmode(mode):
     BCM   - Use Broadcom GPIO 00..nn numbers
     """
     # GPIO = GPIO()
-    time.sleep(1)
     if(mode == BCM):
         setModeDone = True
         _mode = mode


### PR DESCRIPTION
This time.sleep slow down my unit test a lot.
I see no need for it.