### PR TITLE
Made arguments in add_event_detect(..) optional

### DIFF
--- a/Mock/GPIO.py
+++ b/Mock/GPIO.py
@@ -135,7 +135,7 @@ def wait_for_edge(channel,edge,bouncetime,timeout):
     logger.info("Waiting for edge : {} on channel : {} with bounce time : {} and Timeout :{}".format(edge,channel,bouncetime,timeout))
 
 
-def add_event_detect(channel,edge,callback,bouncetime):
+def add_event_detect(channel,edge,callback=None,bouncetime=None):
     """
     Enable edge detection events for a particular GPIO channel.
     channel      - either board pin number or BCM number depending on which mode is set.


### PR DESCRIPTION
According to https://sourceforge.net/p/raspberry-gpio-python/code/ci/default/tree/source/py_gpio.c#l676
the last 2 arguments in `add_event_detect(..)` are optional. This commit reflects that change.