### PR TITLE
fixed variable in output function

### DIFF
--- a/Mock/GPIO.py
+++ b/Mock/GPIO.py
@@ -131,10 +131,10 @@ def output(channels, values):
     else:
         if type(values) is list or type(values) is tuple:
             for value in values:
-                logger.info("Output channel : {} with value : {}".format(channel, value))
+                logger.info("Output channel : {} with value : {}".format(channels, value))
         else:
-            logger.info("Output channel : {} with value : {}".format(channel, values))
-        
+            logger.info("Output channel : {} with value : {}".format(channels, values))
+
 
 def input(channel):
     """


### PR DESCRIPTION
currently even the example fails with the error:

line 136, in output
logger.info("Output channel : {} with value : {}".format(channel, values))
                                                             ^^^^^^^
UnboundLocalError: cannot access local variable 'channel' where it is not associated with a value