### PR TITLE
Fix bug with setmode not setting variables correctly

### DIFF
--- a/Mock/GPIO.py
+++ b/Mock/GPIO.py
@@ -73,6 +73,8 @@ def setmode(mode):
     BCM   - Use Broadcom GPIO 00..nn numbers
     """
     # GPIO = GPIO()
+    global setModeDone
+    global _mode
     if(mode == BCM):
         setModeDone = True
         _mode = mode


### PR DESCRIPTION
Closes #15

`setmode()` function doesn't properly set `setModeDone` and `_mode`.
Fixed now after adding the `global` keyword at the beginning of the function.