### PR TITLE
Format Python code with ruff format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: codespell-project/actions-codespell@v2
     - uses: astral-sh/ruff-action@v3
+    - run: ruff format --check --diff --config='format.quote-style="preserve"'
 
   pytest:
     needs: codespell_and_ruff

--- a/examples/test.py
+++ b/examples/test.py
@@ -1,5 +1,5 @@
 try:
-    import RPi.GPIO as GPIO    
+    import RPi.GPIO as GPIO
 except ImportError:
     import Mock.GPIO as GPIO
 
@@ -9,7 +9,7 @@ print("set mode")
 GPIO.setmode(GPIO.BCM)
 print("set warning false")
 GPIO.setwarnings(False)
-GPIO.setup(15,GPIO.OUT)
-GPIO.output(15,GPIO.HIGH)
+GPIO.setup(15, GPIO.OUT)
+GPIO.output(15, GPIO.HIGH)
 time.sleep(1)
-GPIO.output(15,GPIO.LOW)
+GPIO.output(15, GPIO.LOW)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 from distutils.util import convert_path
 
-long_description ="""
+long_description = """
 # GPIOEmulator
 
 The easiest way to use this package is to install using pip3 for python 3
@@ -51,16 +51,16 @@ with open(ver_path) as ver_file:
     exec(ver_file.read(), pkg_ns)
 
 setup(
-      name='Mock.GPIO',
-      version=pkg_ns['__version__'],
-      description='Mock Library for RPi.GPIO',
-      url='https://github.com/codenio/',
-      author='Aananth K',
-      author_email='aananthraj1995@gmail.com',
-      license='GPL-3.0',
-      packages=find_packages(exclude=[]),
-      install_requires=[],
-      zip_safe=False,
-      long_description_content_type="text/markdown",
-      long_description=long_description,
+    name='Mock.GPIO',
+    version=pkg_ns['__version__'],
+    description='Mock Library for RPi.GPIO',
+    url='https://github.com/codenio/',
+    author='Aananth K',
+    author_email='aananthraj1995@gmail.com',
+    license='GPL-3.0',
+    packages=find_packages(exclude=[]),
+    install_requires=[],
+    zip_safe=False,
+    long_description_content_type="text/markdown",
+    long_description=long_description,
 )


### PR DESCRIPTION
* https://docs.astral.sh/ruff/formatter
* https://docs.astral.sh/ruff/settings/#format_preview

The `--config='format.quote-style="preserve"'` setting can be removed anytime.