### PR TITLE
ruff format fixing quotes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: codespell-project/actions-codespell@v2
     - uses: astral-sh/ruff-action@v3
-    - run: ruff format --check --diff --config='format.quote-style="preserve"'
+    - run: ruff format --check --diff
 
   pytest:
     needs: codespell_and_ruff

--- a/setup.py
+++ b/setup.py
@@ -46,18 +46,18 @@ This library simulates the following functions which are used in the RPi.GPIO li
 
 pkg_ns = {}
 
-ver_path = convert_path('Mock/__init__.py')
+ver_path = convert_path("Mock/__init__.py")
 with open(ver_path) as ver_file:
     exec(ver_file.read(), pkg_ns)
 
 setup(
-    name='Mock.GPIO',
-    version=pkg_ns['__version__'],
-    description='Mock Library for RPi.GPIO',
-    url='https://github.com/codenio/',
-    author='Aananth K',
-    author_email='aananthraj1995@gmail.com',
-    license='GPL-3.0',
+    name="Mock.GPIO",
+    version=pkg_ns["__version__"],
+    description="Mock Library for RPi.GPIO",
+    url="https://github.com/codenio/",
+    author="Aananth K",
+    author_email="aananthraj1995@gmail.com",
+    license="GPL-3.0",
     packages=find_packages(exclude=[]),
     install_requires=[],
     zip_safe=False,


### PR DESCRIPTION
* #26 without `--config='format.quote-style="preserve"'`