### PR TITLE
tox.ini: Improve readability

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@ isolated_build = true
 setenv =
     LOG_LEVEL = Info
 commands =
-    python -m pip install -U pip
-    python -m pip install -e .
+    python -m pip install --upgrade pip
+    python -m pip install --editable .
     python -m pip install pytest
-    python -m pytest -q
+    python -m pytest --quiet
 
 


### PR DESCRIPTION
`pip install -U` can be quite opaque to readers because pip install currently has six `--u*` options, including `--user`.

`pip install --upgrade` makes the intention clearer in code that others will read.

% `python3 -m pip install --help | grep "\-\-u"`
```
  --user                      Install to the Python user install directory for
  -U, --upgrade               Upgrade all specified packages to the newest
  --upgrade-strategy <upgrade_strategy>
  --use-pep517                Use PEP 517 for building source distributions
  --use-feature <feature>     Enable new functionality, that may be backward
  --use-deprecated <feature>  Enable deprecated functionality, that will be
``` 